### PR TITLE
Fix error computing number of sectors in the file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ impl AnvilRegion {
         }
 
         let chunks_metadata = Self::read_header(&mut file)?;
-        let total_sectors = file.metadata()?.len() as u32 / REGION_SECTOR_BYTES_LENGTH as u32;
+        let total_sectors = (file.metadata()?.len() as u32 + (REGION_SECTOR_BYTES_LENGTH as u32 - 1)) / REGION_SECTOR_BYTES_LENGTH as u32;
         let used_sectors = Self::used_sectors(total_sectors, &chunks_metadata);
 
         let region = AnvilRegion {


### PR DESCRIPTION
If the number of bytes in the file isn't an even multiple of 4096 (sector size), it will
undercount the number of sectors by 1, causing an index out of range panic
when marking sectors as used.

For example, if the file was 12287 bytes long, it would compute a length of
2 sectors (8192 bytes) instead of 3 (12288).