### PR TITLE
Reduce crate size by adding 'include' directive.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/eihwaz/anvil-region"
 repository = "https://github.com/eihwaz/anvil-region"
 keywords = ["minecraft", "region", "anvil", "io"]
 readme = "README.md"
+include = ["src/**/*", "LICENSE", "README.md"]
 
 [dependencies]
 byteorder = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/eihwaz/anvil-region"
 repository = "https://github.com/eihwaz/anvil-region"
 keywords = ["minecraft", "region", "anvil", "io"]
 readme = "README.md"
-include = ["src/**/*", "LICENSE", "README.md"]
+include = ["src/**/*", "LICENSE", "README.md", "test/*"]
 
 [dependencies]
 byteorder = "1.3"


### PR DESCRIPTION
Please let me know if there is anything else you would rather
like to have added.

This is the output of 'cargo diet':

```
➜  anvil-region git:(master) cargo diet
┌───────────────────────┬─────────────┐
│ Removed File          │ Size (Byte) │
├───────────────────────┼─────────────┤
│ .gitignore            │          36 │
│ .travis.yml           │         865 │
│ test/empty_region.mca │        8192 │
│ test/region/r.0.0.mca │     1871872 │
└───────────────────────┴─────────────┘
Saved 98% or 1.9 MB in 4 files (of 1.9 MB and 12 files in entire crate)
```