### PR TITLE
Iterator for RegionFolderProvider

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -1,8 +1,3 @@
-use std::path::PathBuf;
-use std::io;
-use std::str::FromStr;
-use std::num::ParseIntError;
-
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
 pub struct RegionPosition {
     pub x: i32,
@@ -20,36 +15,6 @@ impl RegionPosition {
 
         RegionPosition::new(x, z)
     }
-
-    pub fn from_filename(path: &PathBuf) -> Result<RegionPosition, io::Error> {
-        // we can use lossy because of the bound check later
-        let filename = path.file_name().unwrap_or_default().to_string_lossy();
-
-        let parts: Vec<_> = filename.split('.').collect();
-
-        let (x, z) = parse_coords(parts).map_err(|_| io::ErrorKind::InvalidInput)?;
-
-        Ok(RegionPosition::new(x, z))
-    }
-
-    pub fn filename(self) -> String {
-        format!("r.{}.{}.mca", self.x, self.z)
-    }
-}
-
-fn parse_coords(parts: Vec<&str>) -> Result<(i32, i32), ParseIntError> {
-    let correct_format =
-        parts.len() != 4 ||
-            parts[0] != "r" ||
-            parts[3] != "mca";
-
-    if correct_format {
-        // to throw the error (cant instantiate from outside)
-        i32::from_str("")?;
-    }
-
-    Ok((i32::from_str(parts[1])?,
-        i32::from_str(parts[2])?))
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
@@ -75,29 +40,5 @@ impl RegionChunkPosition {
 
     pub(crate) fn metadata_index(&self) -> usize {
         self.x as usize + self.z as usize * 32
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-    use crate::position::RegionPosition;
-
-    #[test]
-    fn test_position_parse() {
-        let mut path = PathBuf::new();
-        path.set_file_name("r.0.0.mca");
-
-        let pos = RegionPosition::from_filename(&path).unwrap();
-        assert_eq!(RegionPosition{ x: 0, z: 0}, pos)
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_position_parse_invalid_format() {
-        let mut path = PathBuf::new();
-        path.set_file_name("this is not a valid region.filename");
-
-        RegionPosition::from_filename(&path).unwrap();
     }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,3 +1,8 @@
+use std::path::PathBuf;
+use std::io;
+use std::str::FromStr;
+use std::num::ParseIntError;
+
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
 pub struct RegionPosition {
     pub x: i32,
@@ -15,6 +20,36 @@ impl RegionPosition {
 
         RegionPosition::new(x, z)
     }
+
+    pub fn from_filename(path: &PathBuf) -> Result<RegionPosition, io::Error> {
+        // we can use lossy because of the bound check later
+        let filename = path.file_name().unwrap_or_default().to_string_lossy();
+
+        let parts: Vec<_> = filename.split('.').collect();
+
+        let (x, z) = parse_coords(parts).map_err(|_| io::ErrorKind::InvalidInput)?;
+
+        Ok(RegionPosition::new(x, z))
+    }
+
+    pub fn filename(self) -> String {
+        format!("r.{}.{}.mca", self.x, self.z)
+    }
+}
+
+fn parse_coords(parts: Vec<&str>) -> Result<(i32, i32), ParseIntError> {
+    let correct_format =
+        parts.len() != 4 ||
+            parts[0] != "r" ||
+            parts[3] != "mca";
+
+    if correct_format {
+        // to throw the error (cant instantiate from outside)
+        i32::from_str("")?;
+    }
+
+    Ok((i32::from_str(parts[1])?,
+        i32::from_str(parts[2])?))
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
@@ -40,5 +75,29 @@ impl RegionChunkPosition {
 
     pub(crate) fn metadata_index(&self) -> usize {
         self.x as usize + self.z as usize * 32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use crate::position::RegionPosition;
+
+    #[test]
+    fn test_position_parse() {
+        let mut path = PathBuf::new();
+        path.set_file_name("r.0.0.mca");
+
+        let pos = RegionPosition::from_filename(&path).unwrap();
+        assert_eq!(RegionPosition{ x: 0, z: 0}, pos)
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_position_parse_invalid_format() {
+        let mut path = PathBuf::new();
+        path.set_file_name("this is not a valid region.filename");
+
+        RegionPosition::from_filename(&path).unwrap();
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -3,6 +3,7 @@ use crate::region::Region;
 use std::fs::{File, OpenOptions, read_dir};
 use std::path::Path;
 use std::{fs, io};
+use std::str::FromStr;
 
 pub trait RegionProvider<S> {
     fn get_region(&self, region_pos: RegionPosition) -> Result<Region<S>, io::Error>;
@@ -22,10 +23,10 @@ impl<'a> FolderRegionProvider<'a> {
 
     // leave implementing this to the specific provider,
     // makes function declaration bearable for now
-    pub fn iter(&self) -> Result<impl Iterator<Item=RegionPosition>, io::Error> {
+    pub fn iter_positions(&self) -> Result<impl Iterator<Item=RegionPosition>, io::Error> {
         let positions: Vec<_> = read_dir(self.folder_path)?
             .filter_map(|dir| dir.ok())
-            .filter_map(|dir| RegionPosition::from_filename(&dir.path()).ok())
+            .filter_map(|dir| region_pos_from_filename(&dir.path()).ok())
             .collect();
 
         Ok(positions.into_iter())
@@ -38,7 +39,7 @@ impl<'a> RegionProvider<File> for FolderRegionProvider<'a> {
             fs::create_dir(self.folder_path)?;
         }
 
-        let region_name = position.filename();
+        let region_name = region_position_filename(position);
         let region_path = self.folder_path.join(region_name);
 
         let file = OpenOptions::new()
@@ -48,5 +49,58 @@ impl<'a> RegionProvider<File> for FolderRegionProvider<'a> {
             .open(region_path)?;
 
         Region::load(position, file)
+    }
+}
+
+fn region_pos_from_filename(path: &Path) -> Result<RegionPosition, io::Error> {
+    // we can use lossy because of the bound check later
+    let filename = path.file_name().unwrap_or_default().to_string_lossy();
+    let parts: Vec<_> = filename.split('.').collect();
+
+    let (x, z) = parse_coords(parts).ok_or_else(|| io::ErrorKind::InvalidInput)?;
+
+    Ok(RegionPosition::new(x, z))
+}
+
+fn region_position_filename(pos: RegionPosition) -> String {
+    format!("r.{}.{}.mca", pos.x, pos.z)
+}
+
+fn parse_coords(parts: Vec<&str>) -> Option<(i32, i32)> {
+    let incorrect_format =
+        parts.len() != 4 ||
+            parts[0] != "r" ||
+            parts[3] != "mca";
+
+    if incorrect_format {
+        return None;
+    }
+
+    Some((i32::from_str(parts[1]).ok()?,
+          i32::from_str(parts[2]).ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use crate::position::RegionPosition;
+    use crate::provider::region_pos_from_filename;
+
+    #[test]
+    fn test_position_parse() {
+        let mut path = PathBuf::new();
+        path.set_file_name("r.-1.1.mca");
+
+        let pos = region_pos_from_filename(&path).unwrap();
+        assert_eq!(RegionPosition{ x: -1, z: 1}, pos)
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_position_parse_invalid_format() {
+        let mut path = PathBuf::new();
+        path.set_file_name("this is not a valid region.filename");
+
+        region_pos_from_filename(&path).unwrap();
     }
 }


### PR DESCRIPTION
the second part of #11 

To keep things simple I only added that the Iterator yields RegionPositions (which also helps when you want to filter it, so you dont need to filter on the already parsed data).

For now i only added it on RegionFolderIterator directly, mainly because returning iterators in a trait function's signature makes lifetimes and function declarations a nightmare, providing a IntoIter even more so. (If someone wants to take a shot at making the Trait have this, go ahead. I wasted too many hours on it.)